### PR TITLE
Adding dockerfile and requirements.txt for hourly ETL

### DIFF
--- a/hourly_pipeline/hourly_etl_scripts/Dockerfile
+++ b/hourly_pipeline/hourly_etl_scripts/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+COPY requirements.txt ./
+
+RUN pip3 install -r requirements.txt
+
+COPY aurora_status.py ./
+
+COPY weather_extract.py ./
+
+COPY hourly_etl.py ./
+
+CMD ["hourly_etl.lambda_handler"]

--- a/hourly_pipeline/hourly_etl_scripts/aurora_status.py
+++ b/hourly_pipeline/hourly_etl_scripts/aurora_status.py
@@ -111,6 +111,12 @@ def insert_values_to_db(conn, country_status: list):
                 naked_eye_visibility)
             VALUES
                 (%s, %s, %s, %s)
+            ON CONFLICT (
+                country_id,
+                aurora_status_at,
+                camera_visibility,
+                naked_eye_visibility)
+            DO NOTHING
             """
     for row in country_status:
         insert_db(conn, query, row)

--- a/hourly_pipeline/hourly_etl_scripts/hourly_etl.py
+++ b/hourly_pipeline/hourly_etl_scripts/hourly_etl.py
@@ -25,6 +25,8 @@ def lambda_handler(event, context):
     insert_into_db(data, conn)
 
     conn.close()
+    print("Finished")
+    return {"statusCode": 200}
 
 
 if __name__ == "__main__":

--- a/hourly_pipeline/hourly_etl_scripts/requirements.txt
+++ b/hourly_pipeline/hourly_etl_scripts/requirements.txt
@@ -1,0 +1,8 @@
+openmeteo-requests
+requests-cache
+retry-requests
+numpy
+pandas
+python-dotenv
+psycopg2-binary
+python-dotenv

--- a/hourly_pipeline/hourly_etl_scripts/weather_extract.py
+++ b/hourly_pipeline/hourly_etl_scripts/weather_extract.py
@@ -26,7 +26,8 @@ def get_connection():
 
 def get_openmeteo():
     """Sets up caching and retries for openmeteo."""
-    cache_session = requests_cache.CachedSession('.cache', expire_after=3600)
+    cache_session = requests_cache.CachedSession(
+        '/tmp/.cache', expire_after=3600)
     retry_session = retry(cache_session, retries=5, backoff_factor=0.2)
     return openmeteo_requests.Client(session=retry_session)
 


### PR DESCRIPTION
Adding dockerfile and requirements.txt to hourly_etl_scripts.
Added ON CONFLICT DO NOTHING to aurora status to fix it crashing when the same status is inserted twice. This won't happen because our pipeline is hourly but if you run it too close together it is possible.
Changed cache file path in weather_extract so that it can work on a lambda.

The function is now up on the cloud and working.

closes #90 